### PR TITLE
As/feature/deploy api contract

### DIFF
--- a/infrastructure/nginx/equitylens.conf
+++ b/infrastructure/nginx/equitylens.conf
@@ -1,15 +1,15 @@
 server {
     listen 80;
-
     server_name equitylens.co.za www.equitylens.co.za;
-
     return 301 https://$host$request_uri;
-
 }
 
 server {
-    listen 80;
+    listen 443 ssl;
     server_name equitylens.co.za www.equitylens.co.za;
+
+    ssl_certificate /etc/letsencrypt/live/equitylens.co.za/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/equitylens.co.za/privkey.pem;
 
     location / {
         proxy_pass http://localhost:3000;

--- a/infrastructure/nginx/equitylens.conf
+++ b/infrastructure/nginx/equitylens.conf
@@ -23,6 +23,15 @@ server {
 server {
     listen 80;
     server_name api.equitylens.co.za;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name api.equitylens.co.za;
+
+    ssl_certificate /etc/letsencrypt/live/equitylens.co.za/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/equitylens.co.za/privkey.pem;
 
     location / {
         proxy_pass http://localhost:8000;

--- a/infrastructure/nginx/equitylens.conf
+++ b/infrastructure/nginx/equitylens.conf
@@ -1,5 +1,14 @@
 server {
     listen 80;
+
+    server_name equitylens.co.za www.equitylens.co.za;
+
+    return 301 https://$host$request_uri;
+
+}
+
+server {
+    listen 80;
     server_name equitylens.co.za www.equitylens.co.za;
 
     location / {


### PR DESCRIPTION
Added HTTPS/SSL configuration for EquityLens using Nginx and Let's Encrypt.

Added HTTP HTTPS redirects using 301.
Configured Nginx to listen on port 443 with SSL.
Configured HTTPS for equitylens.co.za, www.equitylens.co.za, and api.equitylens.co.za.
Used the Let's Encrypt fullchain.pem certificate and privkey.pem private key.
Kept the frontend proxying to port 3000 and the FastAPI backend to port 8000.
Verified the Nginx configuration with nginx -t and reloaded Nginx.
Confirmed the existing certificate covers all three domains.